### PR TITLE
Add pocket-pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Two top-level sections: **Applications** are actual things people have built and
 - [chat-stick](https://github.com/steveruizok/chat-stick) - Hold-to-talk voice interface to Gemini Live on an ESP32-S3 stick, with persistent timers, server-side tools, and OTA updates. ([demo](https://x.com/steveruizok/status/2081132808341176405))
 - [xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) - MCP-based AI chatbot firmware powering a whole ecosystem of talking desk companions.
 - [pixelcat](https://github.com/toddsherman/pixelcat) - Tamagotchi-style pixel cat on an ESP32-S3 AMOLED handheld that learns your schedule, reacts to touch and sound, and can never irrecoverably die. ([demo](https://x.com/tdd/status/2088804262646288883))
+- [pocket-pet](https://github.com/frolic/pocket-pet) - Pocket-Pikachu-style virtual-pet watch on an ESP32-S3 AMOLED dev kit: a pixel pet roams a grass field, counts your real steps, sleeps with the screen, and levels up as you walk.
 
 ### Displays & ambient screens
 


### PR DESCRIPTION
Adds pocket-pet to Companions & AI devices. It's my own project: a Pocket-Pikachu-style virtual-pet watch for the Waveshare ESP32-S3-Touch-AMOLED-2.06 — real step counting, a pet that sleeps when the screen sleeps and levels up as you walk, simulator-first development with the same portable app code running on device.