### PR TITLE
Add ESP-KVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Most of this section (plus pixelcat above) targets one board: the [Waveshare ESP
 
 - [Meshtastic](https://github.com/meshtastic/firmware) - Off-grid, encrypted LoRa mesh messaging; the reference ESP32 radio project.
 
+### Remote access
+
+- [ESP-KVM](https://github.com/espkvm/espkvm) - IP-KVM on an ESP32-P4 and a TC358743 HDMI bridge: captures the target machine's screen, presents itself to that machine as a USB keyboard and mouse, and puts both in a browser, down to the BIOS of a box with no working OS. ([demo](https://espkvm.io/demo/))
+
 ## Tools, utilities & libraries
 
 ### Frameworks & languages


### PR DESCRIPTION
ESP-KVM turns an ESP32-P4 and a TC358743 HDMI-to-CSI bridge into an IP-KVM:  it captures the target machine's HDMI, presents itself to that machine as a USB keyboard and mouse, and serves both to a browser over HTTPS. The target needs no agent and no working OS - you can drive it from the BIOS up.

Disclosure: this is my own project.
On the category: none of the current Applications subcategories fit. It is firmware you flash and run, so by the "what it IS" rule it belongs under Applications rather than Tools - but it is not a companion, a display, home automation, a game, audio or radio. I added a "Remote access" subcategory. Happy to drop it somewhere existing instead if you would rather not carry a category with one entry; "Home & ambient" would be the least-bad fit.
Both links verified. Apache-2.0, builds against ESP-IDF 6.0.1, and the demo link is a live in-browser console that needs no hardware.