### PR TITLE
Add Waycast

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Most of this section (plus pixelcat above) targets one board: the [Waveshare ESP
 ### Radio & mesh
 
 - [Meshtastic](https://github.com/meshtastic/firmware) - Off-grid, encrypted LoRa mesh messaging; the reference ESP32 radio project. `ecosystem`
+- [Waycast](https://github.com/alviso/waycast) - Car-to-car LoRa mesh on an ESP32-P4 touchscreen dashboard: geo-ephemeral hazard reports, convoy position sharing, and offline maps, with no cellular dependency. ([site](https://waycast.io))
 
 ### Remote access
 


### PR DESCRIPTION
Adding Waycast to Radio & mesh — it's my own project (per the self-promotion rule).

Open-source (GPLv3) vehicle-to-vehicle LoRa mesh: an ESP32-P4 with a 7"/10.1" touchscreen on the dashboard, a geo-ephemeral flooding protocol (reports expire by time and radius, nothing uploaded anywhere), convoy position sharing, offline map tiles on SD, and OTA updates. Runs today on two Waveshare P4 kits plus a Raspberry Pi + SX1302 "town node"; step-by-step build guides at https://waycast.io/wiki.

Builds against current ESP-IDF v5.5; actively developed (releases weekly).