### PR TITLE
Add 67

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [esp32-gameos](https://github.com/MikeWilson/esp32-gameos) - A handheld gaming OS for the same AMOLED device: launcher plus six fully procedural games at 60 fps, no engine, no asset files. ([demo](https://x.com/mk_wlsn/status/2089740913195274284)) `s3-amoled`
 - [esp32-fluidbox](https://github.com/V4C38/esp32-fluidbox) - A 3D particle fluid living inside the device's case: ~900 particles slosh with the accelerometer as if liquid sat behind the screen. ([demo](https://x.com/JohannesTscharn/status/2085248949061922855)) `s3-amoled`
 - [puck apps](https://github.com/s0lness/puck/tree/master/apps) - Clock, connect 4, and friends: small apps written once against the puck convention, each running on both of its boards. ([live gallery](https://puck.sylve.org)) `s3-amoled`
+- [67](https://github.com/canwar-dj/67) - Throw-and-catch party game for an ESP32-S3 AMOLED handheld; the screen flickers random numbers while airborne and locks in on catch, landing on a red 67 one time in five to pick a loser. ([demo](https://x.com/kanwardigvijay/status/2090090888659898500)) `s3-amoled`
 
 ### Home & control
 


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware (paste a URL):**
https://x.com/kanwardigvijay/status/2090090888659898500

**Source repository:**
https://github.com/canwar-dj/67

**What is it, one sentence:**
A throw-and-catch party game for the ESP32-S3 AMOLED handheld - the screen flickers random numbers while airborne and locks in on catch, landing on a red 67 one time in five to pick a loser.

**Category:** Play (existing category, added at the bottom alongside the other `s3-amoled` entries).

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

`- [67](https://github.com/canwar-dj/67) - Throw-and-catch party game for an ESP32-S3 AMOLED handheld; the screen flickers random numbers while airborne and locks in on catch, landing on a red 67 one time in five to pick a loser. ([demo](https://x.com/kanwardigvijay/status/2090090888659898500)) `s3-amoled`