### PR TITLE
Add familybox

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 
 - [Meshtastic](https://github.com/meshtastic/firmware) - Off-grid, encrypted LoRa mesh messaging; the reference ESP32 radio project. `ecosystem`
 - [Waycast](https://github.com/alviso/waycast) - Car-to-car LoRa mesh on an ESP32-P4 touchscreen dashboard: geo-ephemeral hazard reports, convoy position sharing, and offline maps, with no cellular dependency. ([site](https://waycast.io)) `p4`
+- [familybox](https://github.com/F86Pilot/familybox) - Photo and voice messages between a travelling parent and a child too young to read: the phone sends, the device shows the photo, and two buttons play the note or record a reply. ([demo](https://x.com/pmtiegs/status/2090134879875051709)) `s3-amoled`
 
 ### Audio & music
 


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware (paste a URL):**
Photo of the device built, powered and displaying a message:
https://github.com/F86Pilot/familybox/blob/main/docs/images/device.jpg
Also visible in the README header alongside a screenshot of the phone app, and in the demo thread linked below.

**Source repository:**
https://github.com/F86Pilot/familybox

**What is it, one sentence:**
A photo-and-voice link between a travelling parent and a child too young to read: the parent sends a photo and a voice note from a phone web app, and the device shows the photo with two buttons — green to play the note as many times as they like, red to record a reply.

**Category:** Radio & comms.

Flagging the judgement call: the other entries in that section are LoRa, so this may look out of place. I picked it because the guidelines say a category answers what a project is *for*, and this is a two-way messaging appliance. **Companions** is the obvious alternative, though that section is AI assistants and virtual pets and this is neither. Happy for it to be moved.

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

`- [familybox](https://github.com/F86Pilot/familybox) - Photo and voice messages between a travelling parent and a child too young to read: the phone sends, the device shows the photo, and two buttons play the note or record a reply. ([demo](https://x.com/pmtiegs/status/2090134879875051709)) `s3-amoled``

---

Notes on tags: tagged `s3-amoled` only. Deliberately **not** `battery` — the board has one and reports its charge, but there is no power management yet and the README says to treat it as a plugged-in device, so the project does not claim it.

The README also documents four undocumented traps on the `s3-amoled` board that cost me a day, in case any are worth folding into `guides/waveshare-amoled-18.md`: `bsp_display_start()` wires LVGL through `lvgl_port_add_disp_rgb()` which flushes nothing on this QSPI panel (black screen, no errors, and Waveshare's own LVGL demo fails the same way); the ES8311 codec must be initialised before the display; `CONFIG_LV_USE_BUILTIN_MALLOC` starves the display driver's DMA buffers; and casting a 3-argument LVGL style setter to `lv_anim_exec_xcb_t` wedges the LVGL task while it holds its mutex.
