### PR TITLE
Add The Lantern Project to Home & control

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 
 - [Tasmota](https://github.com/arendst/Tasmota) - Flash-and-forget firmware giving off-the-shelf smart plugs and lights local MQTT control. `ecosystem`
 - [WLED](https://github.com/Aircoookie/WLED) - The addressable-LED firmware, with effects, segments, and an ecosystem of controllers built around it. `ecosystem`
+- [The Lantern Project](https://github.com/Northstrix/Lantern) - ESP-based addressable RGB LED strip controller with 32 modes and 14 lock screens.
 
 ### Radio & comms
 


### PR DESCRIPTION
Self-promotion disclosure: It's my own project.

Proof that it runs on real hardware: https://github.com/Northstrix/Lantern/blob/main/V1.1/Pictures/IMG_0641.jpg?raw=true

GitHub repository: https://github.com/Northstrix/Lantern

Category: Home & control

Submitted entry:
- [The Lantern Project](https://github.com/Northstrix/Lantern) - ESP-based addressable RGB LED strip controller with 32 modes and 14 lock screens.

Compatibility note: The project's GitHub repository clearly states the following: "Attention: The latest version of Lantern compiles successfully in Arduino IDE 1.8.9 with ESP32 package v2.0.8. There might be compatibility issues with other versions of the ESP32 package for Arduino IDE."