### PR TITLE
Add Vibe Watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [pocket-pet](https://github.com/frolic/pocket-pet) - Pocket-Pikachu-style virtual-pet watch on a Waveshare ESP32-S3-Touch-AMOLED-2.06: a pixel pet roams a grass field, counts your real steps, sleeps with the screen, and levels up as you walk. `Waveshare ESP32-S3-Touch-AMOLED-2.06`
 - [InkSight](https://github.com/datascale-ai/inksight) - E-paper desk companion built from an ESP32-C3 board and a 4.2-inch panel: 24 display modes (weather, poetry, habit tracking), a community mode marketplace, and browser-based flashing.
 - [ESP32 Codex Agent Device](https://github.com/mso96/ESP32-Codex-agent-device) - Physical Codex task-status companion for a Waveshare ESP32-S3-Touch-AMOLED-1.8, with lifecycle tracking, runtime and token metrics, and a procedural avatar. ([demo](https://github.com/mso96/ESP32-Codex-agent-device/blob/main/docs/hardware-demo.jpg)) `Waveshare ESP32-S3-Touch-AMOLED-1.8`
+- [Vibe Watch](https://github.com/GOROman/vibewatch) - Wrist-worn M5Stack StopWatch controller for parallel AI coding agents, with physical approve/reject, haptics, and BLE HID. ([demo](https://x.com/GOROman/status/2094369107781283991)) `M5Stack StopWatch`
 
 ### Displays & ambient
 

--- a/devices.md
+++ b/devices.md
@@ -40,6 +40,11 @@ ESP32-P4 dev kit driving a 7-inch DSI touch panel.
 ESP32-S3 stick with a small display, IMU, microphone and battery.
 [Product page](https://shop.m5stack.com/products/m5sticks3-esp32s3-mini-iot-dev-kit)
 
+## M5Stack StopWatch
+
+ESP32-S3R8 round 1.75" 466x466 AMOLED touch, two buttons, vibration motor, ES8311 audio, BMI270 IMU, 450mAh battery.
+[Product page](https://shop.m5stack.com/products/m5stack-stopwatch-dev-kit-esp32-s3)
+
 ## M5Stack CoreS3
 
 ESP32-S3 in the stackable Core case: 320x240 touch screen, IMU, camera, microphone,


### PR DESCRIPTION
This is my own project. 

**Project:** [Vibe Watch](https://github.com/GOROman/vibewatch) — wrist-worn M5Stack StopWatch controller for parallel AI coding agents (approve/reject, haptics, BLE HID).

**Hardware proof:** photo of the built device running, from [this post](https://x.com/GOROman/status/2094369107781283991) (M5Stack StopWatch). Also on [Hackster](https://www.hackster.io/GOROman/vibe-watch-a-tactile-controller-for-vibe-coding-1c16eb).

**Repro:** README names the board and has PlatformIO build/flash steps.

`M5Stack StopWatch` was not in devices.md yet, so it is added in this PR. Product page: https://shop.m5stack.com/products/m5stack-stopwatch-dev-kit-esp32-s3

Category: Companions (same shelf as ESP32 Codex Agent Device).