### PR TITLE
Add stripe-business-metrics-monitor (Waveshare ESP32-C6-Touch-AMOLED-2.16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [OpenEPaperLink](https://github.com/OpenEPaperLink/OpenEPaperLink) - Repurposes electronic shelf labels into a wireless e-paper display network with an ESP32 access point.
 - [trmnl firmware](https://github.com/usetrmnl/firmware) - Firmware behind the TRMNL e-ink dashboard, an ESP32-C3 driving a battery-friendly plugin ecosystem. `TRMNL`
 - [esp32-vertical-card-compass](https://github.com/austinbirch/esp32-vertical-card-compass) - Simulates an aviation vertical-card magnetic compass on an M5Stack CoreS3: the card swings, overshoots, and reproduces the real instrument's errors. ([demo](https://x.com/austinbirch/status/2086535581773828169)) `M5Stack CoreS3`
+- [stripe-business-metrics-monitor](https://github.com/cosjef/stripe-business-metrics-monitor) - Desk display for a Stripe subscription business, rotating eight screens of MRR and its 30-day trend, signup pace, ARPU compared across joining and leaving cohorts, and failed payments with the revenue at risk. `Waveshare ESP32-C6-Touch-AMOLED-2.16`
 
 ### Play
 

--- a/devices.md
+++ b/devices.md
@@ -19,6 +19,14 @@ ESP32-S3R8, 410x502 touch AMOLED, QMI8658 6-axis IMU, battery support. Larger si
 the 1.8 and a different device: pin map, panel and drivers do not carry over.
 [Product page](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm)
 
+## Waveshare ESP32-C6-Touch-AMOLED-2.16
+
+ESP32-C6, 480x480 CO5300 touch AMOLED on QSPI, CST9217 touch, QMI8658 6-axis
+IMU, AXP2101 PMIC, battery support. The PMIC gates the panel rails and its
+ALDO3 doubles as the panel reset, so power-up ordering matters; Waveshare's
+own ESP-IDF example gives LCD_CS as GPIO5, which is wrong for this board.
+[Product page](https://www.waveshare.com/esp32-c6-touch-amoled-2.16.htm)
+
 ## Waveshare RP2350-Touch-AMOLED-1.8
 
 The same 368x448 touch AMOLED shell as the ESP32-S3 board, on an RP2350 instead. Present


### PR DESCRIPTION
Adds stripe-business-metrics-monitor under Displays & ambient, plus a devices.md entry for the board it runs on, which is not listed yet.

Self-promotion, disclosed: I built it.

**Public source:** MIT, builds from a clean clone with `pio run`.

**Real hardware:** photo of the device running on my desk at the top of the README, showing live figures from my own Stripe account.

**Reproducible:** the README names the board with a product link and gives the flash command. There is nothing to edit before flashing and no credentials at build time; WiFi and the Stripe key are entered on a phone through a captive portal, and the device asks Stripe for a read-only restricted key scoped to Subscriptions and Invoices.

The board entry documents two things that cost me real time: the AXP2101 gates the panel rails and its ALDO3 rail *is* the panel reset, and Waveshare's own ESP-IDF sample documents LCD_CS as GPIO5 when this board uses GPIO15. A wrong CS is silent, every init step still reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)