### PR TITLE
Add HomeworkTimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 
 - [ESP-KVM](https://github.com/espkvm/espkvm) - IP-KVM on a Waveshare ESP32-P4-ETH and a TC358743 HDMI bridge: captures the target machine's screen, presents itself to that machine as a USB keyboard and mouse, and puts both in a browser, down to the BIOS of a box with no working OS. ([demo](https://espkvm.io/demo/)) `Waveshare ESP32-P4-ETH`
 - [Midbar](https://github.com/Northstrix/Midbar) - Hardware data vault for credentials and notes, built across a dozen MCUs including the ESP32: keys derive from the boot-time master password, joined by RFID cards on some versions.
+- [HomeworkTimer](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49) - Homework timer for children with per-subject tracking, weekly reports, schedules, alarms, weather, Wi-Fi time sync and a low-power lock screen. ([demo](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/home-screen.jpg)) `Waveshare ESP32-S3-Touch-LCD-3.49B`
 
 ## Tools, utilities & libraries
 

--- a/devices.md
+++ b/devices.md
@@ -19,6 +19,12 @@ ESP32-S3R8, 410x502 touch AMOLED, QMI8658 6-axis IMU, battery support. Larger si
 the 1.8 and a different device: pin map, panel and drivers do not carry over.
 [Product page](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm)
 
+## Waveshare ESP32-S3-Touch-LCD-3.49B
+
+ESP32-S3R8, 172x640 capacitive touch LCD, audio codecs, microphones, speaker output,
+QMI8658 6-axis IMU, PCF85063 RTC and lithium polymer battery support.
+[Product page](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm)
+
 ## Waveshare RP2350-Touch-AMOLED-1.8
 
 The same 368x448 touch AMOLED shell as the ESP32-S3 board, on an RP2350 instead. Present


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware:**
- [Home screen](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/home-screen.jpg)
- [Subject timer](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/subject-timer.jpg)
- [Three-day weather](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/weather-screen.jpg)
- [Schedule](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/schedule-screen.jpg)
- [Lock screen](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/lock-screen.jpg)

These photos were captured on a Waveshare ESP32-S3-Touch-LCD-3.49B.

**Source repository:**
https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49

**Device it runs on:**
Waveshare ESP32-S3-Touch-LCD-3.49B. It was not yet in devices.md, so this PR adds it using the maker's exact variant name and official product page.

**What is it, one sentence:**
A child-friendly homework timer with per-subject tracking, weekly reports, schedules, alarms, weather, Wi-Fi time sync and a low-power lock screen.

**Category:**
Applications / Utilities & appliances

- [x] This is my own project.