### PR TITLE
Add esp32-spotify-remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 
 - [squeezelite-esp32](https://github.com/sle118/squeezelite-esp32) - Multi-room audio player and AirPlay/Spotify/Bluetooth endpoint on a bare ESP32.
 - [esp32_basic_synth](https://github.com/marcel-licence/esp32_basic_synth) - A polyphonic MIDI synthesizer from one chip and a DAC.
+- [esp32-spotify-remote](https://github.com/seichris/esp32-spotify-remote) - A touchscreen Spotify playback controller with previous, play/pause, and next controls, now-playing metadata, album artwork, and PKCE authorization. `Waveshare ESP32-S3-Touch-AMOLED-2.06`
 
 ### Utilities & appliances
 


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware (paste a URL):**
[README hardware photo](https://github.com/seichris/esp32-spotify-remote/blob/15259e6e31e15895829414ac50cb8e0c38133df9/assets/esp32-spotify.jpg), captured on `Waveshare ESP32-S3-Touch-AMOLED-2.06`.

**Source repository:**
https://github.com/seichris/esp32-spotify-remote

**Device it runs on:** `Waveshare ESP32-S3-Touch-AMOLED-2.06` (already listed in [devices.md](https://github.com/s0lness/awesome-esp32/blob/main/devices.md))

**What is it, one sentence:**
A touchscreen Spotify playback controller with previous, play/pause, and next controls, now-playing metadata, album artwork, and PKCE authorization.

**Category:** Audio & music

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

```text
- [esp32-spotify-remote](https://github.com/seichris/esp32-spotify-remote) - A touchscreen Spotify playback controller with previous, play/pause, and next controls, now-playing metadata, album artwork, and PKCE authorization. `Waveshare ESP32-S3-Touch-AMOLED-2.06`
```