### PR TITLE
Add open-bike-computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [ESP-KVM](https://github.com/espkvm/espkvm) - IP-KVM on a Waveshare ESP32-P4-ETH and a TC358743 HDMI bridge: captures the target machine's screen, presents itself to that machine as a USB keyboard and mouse, and puts both in a browser, down to the BIOS of a box with no working OS. ([demo](https://espkvm.io/demo/)) `Waveshare ESP32-P4-ETH`
 - [Midbar](https://github.com/Northstrix/Midbar) - Hardware data vault for credentials and notes, built across a dozen MCUs including the ESP32: keys derive from the boot-time master password, joined by RFID cards on some versions.
 - [HomeworkTimer](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49) - Homework timer for children with per-subject tracking, weekly reports, schedules, alarms, weather, Wi-Fi time sync and a low-power lock screen. ([demo](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/home-screen.jpg)) `Waveshare ESP32-S3-Touch-LCD-3.49B`
+- [open-bike-computer](https://github.com/seichris/open-bike-computer) - Garmin-mounted bike computer with Apple Maps navigation, live Apple Workout stats, Apple Health and Strava workout sync, and power-meter and cadence-sensor support. `Waveshare ESP32-S3-Touch-AMOLED-1.75` or `Waveshare ESP32-S3-Touch-AMOLED-2.06`
 
 ## Tools, utilities & libraries
 

--- a/devices.md
+++ b/devices.md
@@ -13,6 +13,11 @@ the bus is write-only, so the board cannot report which one it has.
 [Product page](https://www.waveshare.com/product/esp32-related/boards-kits/esp32-s3/esp32-s3-touch-amoled-1.8.htm) ·
 [field guide](guides/waveshare-amoled-18.md)
 
+## Waveshare ESP32-S3-Touch-AMOLED-1.75
+
+ESP32-S3, 466x466 round touch AMOLED, QMI8658 6-axis IMU, battery support.
+[Product page](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm)
+
 ## Waveshare ESP32-S3-Touch-AMOLED-2.06
 
 ESP32-S3R8, 410x502 touch AMOLED, QMI8658 6-axis IMU, battery support. Larger sibling of


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware (paste a URL):**
[Mounted-on-bike hardware photo](https://github.com/seichris/open-bike-computer/blob/853235e89113f3e2063ced5b99e886d500a83e16/docs/images/readme/6.jpg), captured on `Waveshare ESP32-S3-Touch-AMOLED-1.75`.

**Source repository:**
https://github.com/seichris/open-bike-computer

**Device it runs on:** `Waveshare ESP32-S3-Touch-AMOLED-1.75` or `Waveshare ESP32-S3-Touch-AMOLED-2.06`

**What is it, one sentence:**
Garmin-mounted bike computer with Apple Maps navigation, live Apple Workout stats, Apple Health and Strava workout sync, and power-meter and cadence-sensor support.

**Category:** Utilities & appliances

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

```text
- [open-bike-computer](https://github.com/seichris/open-bike-computer) - Garmin-mounted bike computer with Apple Maps navigation, live Apple Workout stats, Apple Health and Strava workout sync, and power-meter and cadence-sensor support. `Waveshare ESP32-S3-Touch-AMOLED-1.75` or `Waveshare ESP32-S3-Touch-AMOLED-2.06`
```