### PR TITLE
Add esp32-ai TinyPoems project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [InkSight](https://github.com/datascale-ai/inksight) - E-paper desk companion built from an ESP32-C3 board and a 4.2-inch panel: 24 display modes (weather, poetry, habit tracking), a community mode marketplace, and browser-based flashing.
 - [ESP32 Codex Agent Device](https://github.com/mso96/ESP32-Codex-agent-device) - Physical Codex task-status companion for a Waveshare ESP32-S3-Touch-AMOLED-1.8, with lifecycle tracking, runtime and token metrics, and a procedural avatar. ([demo](https://github.com/mso96/ESP32-Codex-agent-device/blob/main/docs/hardware-demo.jpg)) `Waveshare ESP32-S3-Touch-AMOLED-1.8`
 - [Vibe Watch](https://github.com/GOROman/vibewatch) - Wrist-worn M5Stack StopWatch controller for parallel AI coding agents, with physical approve/reject, haptics, and BLE HID. ([demo](https://x.com/GOROman/status/2094369107781283991)) `M5Stack StopWatch`
+- [esp32-ai TinyPoems](https://github.com/jeonghopark/esp32-ai) - Runs a tiny poem language model locally on an M5Stack StickS3 and displays generated poems on its LCD. `M5StickS3`
 
 ### Displays & ambient
 


### PR DESCRIPTION
Submitting my own project.

Proof it ran on real hardware is in the project README: the photo under the title shows TinyPoems running on an M5Stack StickS3 LCD.

The README documents the target board, recommended firmware (`m5sticks3_poems`), and flash command. The project is a fork of slvDev/esp32-ai adapted for StickS3 and a locally trained TinyPoems model instead of TinyStories.

Adding one project. Two things reject most PRs, so they come first.

**Proof it ran on real hardware (paste a URL):**
https://raw.githubusercontent.com/jeonghopark/esp32-ai/main/media/previe_01.jpeg
A photo of the thing built and powered, a video of it running, or a live demo anyone can open. A 3D render, a PCB viewer, a generated snapshot or a simulator screenshot is not proof. If your project runs on several devices, say which one this proof was captured on.

**Source repository:**

**Device it runs on:** spelled exactly as [devices.md](https://github.com/s0lness/awesome-esp32/blob/main/devices.md) spells it. If it is not listed there, add a section for it in this pull request: exact name, one line of what it is, link to the maker's product page.

**What is it, one sentence:**

**Category:** pick one that already exists in the README. If nothing fits, name the category you would add and the second project that would go in it, since a category with one entry waits.

- [ ] This is my own project. (Fine, say so.)

Entry line, ready to paste:

`- [name](repo) - What it is, one sentence ending with a period. `Device Name``
