### PR TITLE
Add family-mruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [esp-hal](https://github.com/esp-rs/esp-hal) - Bare-metal Rust for ESP32 chips.
 - [MicroPython](https://github.com/micropython/micropython) - Python on the chip, with first-class ESP32 support.
 - [ESPHome](https://github.com/esphome/esphome) - Describe a device in YAML, get firmware; the default way ESP32s enter Home Assistant.
+- [Family mruby](https://github.com/family-mruby/family-mruby) - Multitasking OS running mruby, MicroPython, Lua and BASIC on the chip, with a windowed desktop and an on-device editor. ([demo](https://www.youtube.com/watch?v=9vkRaOoxJJI)) `M5Stack Tab5` or `Narya board`
 
 ### Utilities & SDKs
 

--- a/devices.md
+++ b/devices.md
@@ -93,6 +93,13 @@ Discontinued by M5Stack, and the CoreS3 above is its successor in the same case,
 what you can still get before buying a project that names it.
 [Product page](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit-v1-1)
 
+## M5Stack Tab5
+
+ESP32-P4 with an ESP32-C6 radio co-processor for Wi-Fi 6, a 5-inch 1280x720 MIPI-DSI
+touch screen, a 2MP MIPI-CSI camera, ES8388 audio codec with dual microphones and a
+speaker, and a removable NP-F550 battery.
+[Product page](https://shop.m5stack.com/products/m5stack-tab5-iot-development-kit-esp32-p4)
+
 ## Ulanzi Smart Pixel Clock TC001
 
 A shipped consumer clock built on an ESP32 driving a 32x8 addressable LED matrix, with
@@ -103,6 +110,15 @@ light and temperature sensors, buttons and a battery.
 
 A shipped ESP32-C3 e-ink dashboard, sold assembled, with a plugin ecosystem behind it.
 [Product page](https://trmnl.com)
+
+## Narya board
+
+Open hardware built for Family mruby Retro: an ESP32-S3 paired with an ESP32-WROVER that
+drives NTSC composite video and I2S audio, so the board plugs into a TV, with a USB host
+port for a keyboard and mouse, an SD card slot and an RTC. Sold assembled in small
+batches, and the KiCAD sources are published.
+[Product page](https://booth.pm/ja/items/8128031) ·
+[design files](https://github.com/family-mruby/narya-board)
 
 ## No single device
 


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware (paste a URL):**
[Family mruby OS on Tab5, hardware write-up with photos](https://www.hackster.io/kishima7/family-mruby-os-for-tab5-boot-your-tab5-into-a-ruby-pc-24538f), captured on `M5Stack Tab5`.
[Demo video](https://www.youtube.com/watch?v=9vkRaOoxJJI) of the OS booting and driving a TV over NTSC composite, captured on `Narya board`.

**Source repository:**
https://github.com/family-mruby/family-mruby

**Device it runs on:** `M5Stack Tab5` or `Narya board`. Neither was in devices.md, so this PR adds both, each with its maker's product page. The Tab5 is M5Stack's, off the shelf. The Narya board is the project's own open hardware: I sell it assembled in small batches, so disclosing that the product page it links is my own shop, and the KiCAD sources are published alongside it.

**What is it, one sentence:**
A multitasking OS and development environment that runs mruby, MicroPython, Lua and BASIC on the microcontroller itself, with a windowed desktop, an on-device editor, and graphics and audio APIs.

**Category:** Frameworks & languages

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

```text
- [Family mruby](https://github.com/family-mruby/family-mruby) - Multitasking OS running mruby, MicroPython, Lua and BASIC on the chip, with a windowed desktop and an on-device editor. ([demo](https://www.youtube.com/watch?v=9vkRaOoxJJI)) `M5Stack Tab5` or `Narya board`
```

Three links that complement the repo rather than replace it, none of them offered as the hardware proof above:

- https://family-mruby.github.io/studio/ — the OS built to WebAssembly, running in the browser with no hardware and no install: desktop, shell, editor, and Ruby that actually executes. It is an emulator, so it proves nothing about hardware, but it is the fastest way to see what the thing is.
- https://family-mruby.github.io/family-mruby-installer/ — WebSerial flasher for both boards, so a reader with either board is running it in a couple of minutes.
- https://family-mruby.github.io — the documentation.
