### PR TITLE
Add Codex Microphone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [InkSight](https://github.com/datascale-ai/inksight) - E-paper desk companion built from an ESP32-C3 board and a 4.2-inch panel: 24 display modes (weather, poetry, habit tracking), a community mode marketplace, and browser-based flashing.
 - [ESP32 Codex Agent Device](https://github.com/mso96/ESP32-Codex-agent-device) - Physical Codex task-status companion for a Waveshare ESP32-S3-Touch-AMOLED-1.8, with lifecycle tracking, runtime and token metrics, and a procedural avatar. ([demo](https://github.com/mso96/ESP32-Codex-agent-device/blob/main/docs/hardware-demo.jpg)) `Waveshare ESP32-S3-Touch-AMOLED-1.8`
 - [Vibe Watch](https://github.com/GOROman/vibewatch) - Wrist-worn M5Stack StopWatch controller for parallel AI coding agents, with physical approve/reject, haptics, and BLE HID. ([demo](https://x.com/GOROman/status/2094369107781283991)) `M5Stack StopWatch`
+- [Codex Microphone](https://github.com/seichris/codex-microphone) - Physical Codex Desktop attention inbox and privacy-gated USB or paired Wi-Fi microphone companion for a Waveshare ESP32-S3-Touch-AMOLED-2.06. ([demo](https://github.com/seichris/codex-microphone/blob/main/docs/codex-mic-github.jpg)) `Waveshare ESP32-S3-Touch-AMOLED-2.06`
 
 ### Displays & ambient
 


### PR DESCRIPTION
Adding one project. This is my own project.

**Proof it ran on real hardware (paste a URL):**
[Photo of Codex Microphone running on the Waveshare ESP32-S3-Touch-AMOLED-2.06](https://github.com/seichris/codex-microphone/blob/main/docs/codex-mic-github.jpg), captured on `Waveshare ESP32-S3-Touch-AMOLED-2.06`. The photo shows the powered board displaying the attention inbox while the companion microphone state is active on the Mac.

**Source repository:**
https://github.com/seichris/codex-microphone

**Device it runs on:** `Waveshare ESP32-S3-Touch-AMOLED-2.06`, already listed in [devices.md](https://github.com/s0lness/awesome-esp32/blob/main/devices.md).

**What is it, one sentence:**
A physical Codex Desktop attention inbox and privacy-gated USB or paired Wi-Fi microphone companion.

**Category:** Companions (existing category).

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

```text
- [Codex Microphone](https://github.com/seichris/codex-microphone) - Physical Codex Desktop attention inbox and privacy-gated USB or paired Wi-Fi microphone companion for a Waveshare ESP32-S3-Touch-AMOLED-2.06. ([demo](https://github.com/seichris/codex-microphone/blob/main/docs/codex-mic-github.jpg)) `Waveshare ESP32-S3-Touch-AMOLED-2.06`
```
