### PR TITLE
Add ESP32Drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [openHASP](https://github.com/HASwitchPlate/openHASP) - Build custom touchscreen control panels for home automation, driven over MQTT.
 - [psiop](https://github.com/aap/psiop) - A compact software 3D rendering library for the ESP32. ([demo](https://x.com/Alacritic_Super/status/2089987821352403387))
 - [openai-realtime-embedded](https://github.com/openai/openai-realtime-embedded) - OpenAI's official SDK for talking to the Realtime API over WebRTC from an ESP32-S3.
+- [ESP32Drop](https://github.com/s-iwaki-d/ESP32Drop) - Arduino library that speaks Apple Wireless Direct Link so an ESP32-S3 shows up in the AirDrop share sheet and receives a photo from an iPhone or Mac, or sends one back, with no pairing and no Wi-Fi network. ([demo](https://youtu.be/D7EdZe_lp2o)) `M5Stack StopWatch`
 
 ### Emulators & simulators
 


### PR DESCRIPTION
Adding one project.

**Proof it ran on real hardware (paste a URL):**
https://youtu.be/D7EdZe_lp2o — the `ShowReceivedImage` example: the device is picked in an iPhone's AirDrop share sheet, receives a photo and puts it on the screen. Captured on `M5Stack StopWatch`.
https://youtu.be/QiWLgiBhAhg — the sending direction: the device offers a file over AirDrop and the receiving Apple device's own Accept dialog takes it. Recorded with a development build of the same library rather than the shipped `GreetingCard` example, on the same `M5Stack StopWatch`.

**Source repository:**
https://github.com/s-iwaki-d/ESP32Drop

**Device it runs on:** `M5Stack StopWatch` (already in devices.md). The library needs an ESP32-S3 with PSRAM and takes the radio exclusively; the StopWatch is the one board it has been verified on, so it is the only device named.

**What is it, one sentence:**
An Arduino library that re-implements Apple Wireless Direct Link and the AirDrop protocol so an ESP32-S3 can receive a photo from an iPhone or Mac and send one back, with no pairing, no Apple ID and no Wi-Fi network.

**Category:** Tools, utilities & libraries / Utilities & SDKs

- [x] This is my own project. (Fine, say so.)

Entry line, ready to paste:

```text
- [ESP32Drop](https://github.com/s-iwaki-d/ESP32Drop) - Arduino library that speaks Apple Wireless Direct Link so an ESP32-S3 shows up in the AirDrop share sheet and receives a photo from an iPhone or Mac, or sends one back, with no pairing and no Wi-Fi network. ([demo](https://youtu.be/D7EdZe_lp2o)) `M5Stack StopWatch`
```

Two limits worth knowing, both stated in the README: "Contacts Only" is out of reach by design (it needs Apple-signed identity material), and the link layer cannot coexist with `WiFi.begin()`. Receiving and sending are separate builds. The host test suites run in CI; the three examples are built and flashed with the scripts in `tools/`.
