### PR TITLE
Add tempmeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [Midbar](https://github.com/Northstrix/Midbar) - Hardware data vault for credentials and notes, built across a dozen MCUs including the ESP32: keys derive from the boot-time master password, joined by RFID cards on some versions.
 - [HomeworkTimer](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49) - Homework timer for children with per-subject tracking, weekly reports, schedules, alarms, weather, Wi-Fi time sync and a low-power lock screen. ([demo](https://github.com/doublemarkpro/HomeworkTimer-ESP32-S3-Touch-LCD-3.49/blob/main/docs/hardware/home-screen.jpg)) `Waveshare ESP32-S3-Touch-LCD-3.49B`
 - [open-bike-computer](https://github.com/seichris/open-bike-computer) - Garmin-mounted bike computer paired with its iPhone and Apple Watch app: Apple Maps navigation, live workout stats, Apple Health and Strava sync, power-meter and cadence sensors. `Waveshare ESP32-S3-Touch-AMOLED-1.75` or `Waveshare ESP32-S3-Touch-AMOLED-2.06`
+- [tempmeter](https://github.com/AideaHandesen-dvs/tempmeter) - Room thermometer built from an ESP32-C3 and a BME280 for about ¥1,500: temperature and humidity alternate on a TM1637 7-segment display, pressure and a JSON endpoint arrive over Wi-Fi, and the network is set from a phone through a captive portal. ([demo](https://youtu.be/Tk6F4vo_uOE))
 
 ## Tools, utilities & libraries
 

--- a/devices.md
+++ b/devices.md
@@ -138,6 +138,9 @@ instead:
 - **esp32-lvgl-watchface**: any board with a 240x240 display that LVGL can drive.
 - **Midbar**: versions exist for a dozen microcontrollers including the ESP32, each with
   its own parts list and its own build.
+- **tempmeter**: an ESP32-C3 SuperMini, a BME280 breakout and a TM1637 4-digit
+  display, wired by you, in a 3D-printed case. The README gives the pin map and the
+  transmit-power setting the SuperMini needs to keep its access point up.
 - **Tasmota, WLED, Meshtastic, ESPHome, xiaozhi-esp32**: firmware ecosystems running on
   hundreds to thousands of boards. Each publishes the compatibility list; no short answer
   here would be true.


### PR DESCRIPTION
My own project — disclosing that up front. Sylve invited it on X: https://x.com/sylvechv/status/2097012201684947156

**What it is.** A room thermometer I built because the house had none, for about ¥1,500 of parts. An ESP32-C3 SuperMini reads a BME280 and alternates temperature and humidity on a TM1637 7-segment display; the web page adds pressure, and there is a JSON endpoint. Wi-Fi is configured from a phone through a captive portal, so no credentials sit in the firmware.

**It ran on real hardware.** Video of the finished build running: https://youtu.be/Tk6F4vo_uOE (Japanese). Captured on the ESP32-C3 SuperMini described below — the only board it has run on.

**Reproducible.** The source is public, the README gives the parts, the pin map, the PlatformIO flashing steps and the first-run captive-portal setup, and `platformio.ini` declares the three libraries.

**Category.** Added to the bottom of Applications › Utilities & appliances. It is an appliance doing one job in the house; Displays & ambient was the other candidate, but the display reads out its own sensor rather than being the point of the device. Happy to move it.

**Device.** No single device: a bare ESP32-C3 plus parts wired by hand, so the entry names none and `devices.md` gains a bullet under "No single device" saying what it takes.
