### PR TITLE
Add vkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Elsewhere, write-ups by @ardchain posted as threads on X (third-party, not repo 
 - [open-bike-computer](https://github.com/seichris/open-bike-computer) - Garmin-mounted bike computer paired with its iPhone and Apple Watch app: Apple Maps navigation, live workout stats, Apple Health and Strava sync, power-meter and cadence sensors. `Waveshare ESP32-S3-Touch-AMOLED-1.75` or `Waveshare ESP32-S3-Touch-AMOLED-2.06`
 - [tempmeter](https://github.com/AideaHandesen-dvs/tempmeter) - Room thermometer built from an ESP32-C3 and a BME280 for about ¥1,500: temperature and humidity alternate on a TM1637 7-segment display, pressure and a JSON endpoint arrive over Wi-Fi, and the network is set from a phone through a captive portal. ([demo](https://youtu.be/Tk6F4vo_uOE))
 - [esp_ble_finder](https://github.com/khlebobul/esp_ble_finder) - BLE finder that hunts a misplaced phone by RSSI, with a dark dotted direction UI, a bar that fills as you close in, and speaker clicks that speed up with signal strength. `Waveshare ESP32-S3-Touch-AMOLED-1.8`
+- [vkey](https://github.com/vaulttec-dev/vaulttec-key) - USB hardware key for TOTP codes, passwords and whole project `.env` files: AES-256-GCM under a PIN through Argon2id, bound to an eFuse HMAC key so a flash dump without the chip is useless, Secure Boot v2 on, and a button press for every secret — a tap releases, a five-second hold wipes, a double tap exports an encrypted backup. Bare-metal Rust, no ESP-IDF; no HID on the C6, so no FIDO. `Waveshare ESP32-C6-Zero`
 
 ## Tools, utilities & libraries
 


### PR DESCRIPTION
https://github.com/vaulttec-dev/vaulttec-key

vkey is a USB hardware key on a Waveshare ESP32-C6-Zero that stores TOTP secrets, passwords and whole project `.env` files. Secrets are AES-256-GCM under a key derived from an 8-digit PIN with Argon2id and passed through an HMAC key burned into the chip's eFuse, so a flash dump without that exact chip is useless. Secure Boot v2 is enabled, and every code, password or `.env` requires a physical button press — three different gestures separate use, wipe and encrypted backup.

Firmware is bare-metal Rust on esp-hal: `no_std`, no allocator anywhere, `unsafe_code = "forbid"` and `clippy::pedantic` as errors, no ESP-IDF, no RTOS and no radio crate. The host side is a single static CLI binary that flashes the board and speaks a framed protocol whose definition is one file compiled into both ends. Apache-2.0.

Stated plainly rather than buried: the C6's USB is a hard-wired Serial/JTAG block, so HID and therefore FIDO/WebAuthn are impossible on this hardware and it does nothing against phishing; an ESP32 is not a secure element, and the published fault-injection work on the C3/C6 (Espressif AR2023-007) is not addressed. The repo's threat model documents this, along with a list of marketing claims the project forbids itself. Nothing is for sale.
